### PR TITLE
fix(swagger): 修复当swagger扫描异常的问题

### DIFF
--- a/bootstrap/src/main/java/io/geekidea/springbootplus/config/Swagger2Config.java
+++ b/bootstrap/src/main/java/io/geekidea/springbootplus/config/Swagger2Config.java
@@ -162,6 +162,8 @@ public class Swagger2Config {
             basePackages = basePackage.split(SPLIT_COMMA);
         } else if (basePackage.contains(SPLIT_SEMICOLON)) {
             basePackages = basePackage.split(SPLIT_SEMICOLON);
+        } else{
+            basePackages = new String[]{basePackage};
         }
         log.info("swagger scan basePackages:" + Arrays.toString(basePackages));
         return basePackages;


### PR DESCRIPTION
修复当swagger的扫描包为1个的并且未加逗号时 `读取失败`的问题